### PR TITLE
Add C4 model for the system architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# structurizr
+/docs/.structurizr
+/docs/workspace.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+c4-lite-server:
+	docker run \
+		--interactive \
+		--name c4-lite-server \
+		--publish 8080:8080 \
+		--rm \
+		--tty \
+		--volume ${PWD}/docs:/usr/local/structurizr \
+		structurizr/lite

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,9 @@
+# Software architecture
+
+The software architecture is define in the [workspace.dsl](workspace.dsl) file.
+We used the [Structurizr DSL](https://structurizr.com/help/dsl) to describe its
+building blocks and relationships.
+Use the [Structurizr Lite](https://structurizr.com/help/lite) to visualize the
+diagrams.
+Run the `make c4-lite-server` command to spin up a local server using Docker and
+access http://localhost:8080 to interact with the diagrams in a browser.

--- a/docs/workspace.dsl
+++ b/docs/workspace.dsl
@@ -1,0 +1,116 @@
+workspace {
+
+    model {
+        buyer = person "Buyer"
+
+        rifaSystem = softwareSystem "Rifa Online" {
+            ui = container "User Interface" {
+                description "User interface of the rifa online."
+                technology "HTML, CSS and JavaScript"
+            }
+
+            httpService = container "Web Application" {
+                description "Rifa online web application."
+                technology "Next.js"
+
+                orm = component "ORM" {
+                    technology "Prisma"
+                }
+                migration = component "Migration" {
+                    description "Migration script"
+                    technology "Prisma"
+                }
+                rifaModule = component "Rifa Module" {
+                    description "The rifa module"
+                    technology "Next.js"
+                }
+                buyerModule = component "Buyer Module" {
+                    description "The buyer module"
+                    technology "Next.js"
+                }
+            }
+
+            database = container "Database" {
+                description "Application's relational database."
+                technology "Relational database schema"
+                tags "Database"
+            }
+        }
+
+        # relationships between people and software systems
+        buyer -> rifaSystem "Uses"
+        buyer -> ui "Interacts with"
+
+        # relationships between containers
+        ui -> httpService "Access" "HTTPS"
+        httpService -> database "Reads from and writes to" "MySQL Protocol/SSL"
+
+        # relationships between components
+        orm -> database
+        migration -> orm
+        rifaModule -> orm
+        buyerModule -> orm
+
+        deploymentEnvironment "Live" {
+            deploymentNode "Web Browser" {
+                technology "Chrome, Firefox, Edge, Safari"
+                containerInstance ui
+            }
+
+            deploymentNode "Cloud Services" {
+                deploymentNode "Cloud Region: AWS sa-east-1, São Paulo, Brazil" {
+                    technology "AWS and other cloud providers running on AWS"
+
+                    deploymentNode "Vercel" {
+                        description "Serverless web application deployment."
+                        containerInstance httpService
+                    }
+                    deploymentNode "PlanetScale" {
+                        description "MySQL-compatible serverless database platform."
+                        containerInstance database
+                    }
+                }
+            }
+        }
+    }
+
+    views {
+        systemContext rifaSystem {
+            include *
+            autolayout lr
+        }
+
+        container rifaSystem {
+            include *
+            autolayout lr 400 400
+        }
+
+        component httpService {
+            include *
+            autolayout tb
+        }
+
+        deployment rifaSystem "Live" {
+            include *
+            autolayout lr 600 600
+        }
+
+        styles {
+            element "Element" {
+                shape Roundedbox
+                background #ffffff
+            }
+            element "Person" {
+                shape Person
+                color #ffffff
+                background #08427b
+            }
+            element "Database" {
+                shape Cylinder
+            }
+            element "Infrastructure Node" {
+                shape RoundedBox
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change includes the make target c4-lite-server that allows us to run the Structurizr Lite server to visualize and interact with the diagrams.

## C4 model diagrams

### Context

![structurizr-1-RifaOnline-SystemContext](https://user-images.githubusercontent.com/322159/176255873-7a0e66ed-41f6-4be0-b604-a25214477c8f.svg)

### Containers

![structurizr-1-RifaOnline-Container](https://user-images.githubusercontent.com/322159/176255871-a07b3a01-4fff-4b98-ae04-ff2ca3d78666.svg)

### Components (Web Application)

![structurizr-1-RifaOnline-WebApplication-Component](https://user-images.githubusercontent.com/322159/176255869-51393677-4a0d-4820-ba1d-28f09c01306c.svg)

### Deployment

![structurizr-1-RifaOnline-Live-Deployment](https://user-images.githubusercontent.com/322159/176255863-dbd29025-8d86-41d4-9c3e-2d096b9c00e8.svg)